### PR TITLE
Edited item is added again after being edited

### DIFF
--- a/ListViewMAUI/ViewModel/ViewModel.cs
+++ b/ListViewMAUI/ViewModel/ViewModel.cs
@@ -151,7 +151,10 @@ namespace ListViewMAUI
 
         internal async void OnSaveContact()
         {
-            contactsInfo.Add(SelectedItem);
+            if (!contactsInfo.Contains(SelectedItem))
+            {
+                contactsInfo.Add(SelectedItem);
+            }
             await App.Current.MainPage.Navigation.PopAsync();
         }
 


### PR DESCRIPTION
Description
Edited item is added again after it is edit and it was added at the bottom of the group

Solution 
Restricted adding the item if the item is already in the collection.

Before

https://github.com/user-attachments/assets/d34cdde1-fa9b-4e8c-9eee-14b8ae12717d



After

https://github.com/user-attachments/assets/1df22267-15d5-4e62-97fe-ccdef85d0e3c

